### PR TITLE
Center the text in the "run" button.

### DIFF
--- a/solitaryDongeon/ViewController.m
+++ b/solitaryDongeon/ViewController.m
@@ -168,6 +168,7 @@
 	_discardBar.frame = CGRectMake(0, 0, 0, 0);
 	
 	_runButton.backgroundColor = [UIColor blackColor];
+	_runButton.titleEdgeInsets = UIEdgeInsetsMake(2.5, 0, 0, 0);
 	_runButton.layer.cornerRadius = margin/4;
 	_runButton.layer.borderColor = [[UIColor whiteColor] CGColor];
 	_runButton.layer.borderWidth = 1;


### PR DESCRIPTION
Is the a-little-higher-than-centered text in the "run" button intentional?  It was bothering me slightly while playing, so when I found the source was online I had to go and fix it :)

Here are before and after images:

![Before](https://cloud.githubusercontent.com/assets/114075/7522806/836bdda6-f4ac-11e4-900e-664be46ca527.png)

![After](https://cloud.githubusercontent.com/assets/114075/7522811/885bc196-f4ac-11e4-8d96-25f6706eea06.png)
