### PR TITLE
Use a value based on the margin.

### DIFF
--- a/solitaryDongeon/ViewController.m
+++ b/solitaryDongeon/ViewController.m
@@ -168,7 +168,7 @@
 	_discardBar.frame = CGRectMake(0, 0, 0, 0);
 	
 	_runButton.backgroundColor = [UIColor blackColor];
-	_runButton.titleEdgeInsets = UIEdgeInsetsMake(2.5, 0, 0, 0);
+	_runButton.titleEdgeInsets = UIEdgeInsetsMake(margin/8, 0, 0, 0);
 	_runButton.layer.cornerRadius = margin/4;
 	_runButton.layer.borderColor = [[UIColor whiteColor] CGColor];
 	_runButton.layer.borderWidth = 1;


### PR DESCRIPTION
I tested it on the 6+ simulator and the button was still too high.  It looks like the value should be based on the margin after all.

Before:
![Before](https://cloud.githubusercontent.com/assets/114075/7523101/518b3e56-f4ae-11e4-9e08-1f08f9f0d246.png)

After:
![After](https://cloud.githubusercontent.com/assets/114075/7523107/5750f952-f4ae-11e4-9565-8251b65a1fe3.png)
